### PR TITLE
bugfix: properly parse constants from class-constants and non-class-constants

### DIFF
--- a/src/Parser/PhpParser/ArgumentValueParser.php
+++ b/src/Parser/PhpParser/ArgumentValueParser.php
@@ -89,6 +89,10 @@ final class ArgumentValueParser
                 : LiteralStringVariableInContextParser::parse($expr, $context);
         }
 
+        if ($expr instanceof Expr\ClassConstFetch || $expr instanceof Expr\ConstFetch) {
+            return VariableFromConstInContextParser::parse($expr, $context);
+        }
+
         throw new InvalidArgumentException(sprintf(self::UNPARSABLE_ARGUMENT_VALUE, $expr->getType()));
     }
 }

--- a/src/Parser/PhpParser/VariableFromConstInContextParser.php
+++ b/src/Parser/PhpParser/VariableFromConstInContextParser.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boesing\PsalmPluginStringf\Parser\PhpParser;
+
+use InvalidArgumentException;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Psalm\Context;
+
+use function assert;
+use function get_class;
+use function sprintf;
+
+final class VariableFromConstInContextParser
+{
+    /** @var ClassConstFetch|ConstFetch */
+    private Expr $expr;
+
+    private Context $context;
+
+    /**
+     * @param ClassConstFetch|ConstFetch $expr
+     */
+    private function __construct(Expr $expr, Context $context)
+    {
+        $this->expr    = $expr;
+        $this->context = $context;
+    }
+
+    /**
+     * @param ClassConstFetch|ConstFetch $expr
+     */
+    public static function parse(
+        Expr $expr,
+        Context $context
+    ): string {
+        return (new self($expr, $context))->toString();
+    }
+
+    private function toString(): string
+    {
+        if ($this->expr instanceof ClassConstFetch) {
+            return $this->parseClassConstant($this->expr, $this->context);
+        }
+
+        return $this->parseConstant($this->expr, $this->context);
+    }
+
+    private function parseClassConstant(ClassConstFetch $expr, Context $context): string
+    {
+        if (! $expr->class instanceof Name) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected an instance of "%s" as ClassConstFetch::$class property, got: %s',
+                Name::class,
+                get_class($expr->class)
+            ));
+        }
+
+        if (! $expr->name instanceof Identifier) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected an instance of "%s" as ClassConstFetch::$name property, got: %s',
+                Identifier::class,
+                get_class($expr->name)
+            ));
+        }
+
+        $className = $expr->class->toString();
+
+        if ($expr->class->toLowerString() === 'self') {
+            assert($context->self !== null);
+            $className = $context->self;
+        }
+
+        $constant = sprintf('%s::%s', $className, $expr->name->toString());
+
+        if (isset($context->vars_in_scope[$constant])) {
+            return $context->vars_in_scope[$constant]->getId();
+        }
+
+        throw new InvalidArgumentException(sprintf('Could not find class constant "%s" in scope.', $constant));
+    }
+
+    private function parseConstant(ConstFetch $expr, Context $context): string
+    {
+        $constant = (string) $expr->name;
+
+        if (isset($context->vars_in_scope[$constant])) {
+            return $context->vars_in_scope[$constant]->getId();
+        }
+
+        throw new InvalidArgumentException(sprintf('Could not find constant "%s" in scope.', $constant));
+    }
+}

--- a/tests/acceptance/SprintfNonEmptyString.feature
+++ b/tests/acceptance/SprintfNonEmptyString.feature
@@ -210,3 +210,37 @@ Feature: non empty template passed to sprintf results in non-empty-string
       | Type  | Message |
       | ArgumentTypeCoercion | Argument 1 of nonEmptyString expects non-empty-string, parent type string provided |
     And I see no other errors
+
+  Scenario: template is non-empty and loaded from constant
+    Given I have the following code
+    """
+      namespace {
+        const CONSTANT_WITH_NON_EMPTY_STRING = 'bar baz %s';
+
+        final class Foo
+        {
+             public const CONSTANT_WITH_NON_EMPTY_STRING = 'foo bar %s';
+
+             /** @return non-empty-string */
+             public function createNonEmptyString(): string
+             {
+                  return sprintf(self::CONSTANT_WITH_NON_EMPTY_STRING, 'baz');
+             }
+        }
+
+        nonEmptyString(sprintf(Foo::CONSTANT_WITH_NON_EMPTY_STRING, 'baz'));
+        nonEmptyString(sprintf(\DifferentNamespace\Whatever::CONSTANT_WITH_NON_EMPTY_STRING, 'baz'));
+        /** @psalm-suppress ArgumentTypeCoercion Can be removed after https://github.com/vimeo/psalm/issues/7920 got fixed */
+        nonEmptyString(sprintf(\DifferentNamespace\CONSTANT_WITH_NON_EMPTY_STRING, 'baz'));
+        nonEmptyString(sprintf(CONSTANT_WITH_NON_EMPTY_STRING, 'baz'));
+      }
+      namespace DifferentNamespace {
+        const CONSTANT_WITH_NON_EMPTY_STRING = 'bar baz %s';
+        final class Whatever
+        {
+            public const CONSTANT_WITH_NON_EMPTY_STRING = 'foo bar %s';
+        }
+      }
+    """
+    When I run psalm
+    Then I see no errors


### PR DESCRIPTION
closes #82 
releates to vimeo/psalm#7920