### PR TITLE
Bugfix: detect function/method return types when directly passed to stringf-functions

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,6 +18,7 @@
         <exclude name="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn.UselessIfCondition"/>
         <exclude name="Generic.Files.LineLength.TooLong"/>
         <exclude name="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
+        <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion.RequiredExplicitAssertion"/>
     </rule>
 
     <file>src</file>

--- a/src/EventHandler/PossiblyInvalidArgumentForSpecifierValidator.php
+++ b/src/EventHandler/PossiblyInvalidArgumentForSpecifierValidator.php
@@ -14,6 +14,7 @@ use Psalm\Issue\PossiblyInvalidArgument;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\AfterEveryFunctionCallAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterEveryFunctionCallAnalysisEvent;
+use Psalm\StatementsSource;
 use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNumericString;
@@ -69,14 +70,16 @@ final class PossiblyInvalidArgumentForSpecifierValidator implements AfterEveryFu
         Assert::allIsInstanceOf($arguments, Arg::class);
         Assert::isNonEmptyList($arguments);
 
-        $context = $event->getContext();
+        $context          = $event->getContext();
+        $statementsSource = $event->getStatementsSource();
 
         /** @psalm-suppress InvalidScalarArgument */
         (new self(
             $functionId,
             $arguments
         ))->assert(
-            new CodeLocation($event->getStatementsSource(), $expression),
+            $statementsSource,
+            new CodeLocation($statementsSource, $expression),
             $context,
             PhpVersion::fromCodebase($event->getCodebase())
         );
@@ -86,6 +89,7 @@ final class PossiblyInvalidArgumentForSpecifierValidator implements AfterEveryFu
      * @psalm-param positive-int $phpVersion
      */
     public function assert(
+        StatementsSource $statementsSource,
         CodeLocation $codeLocation,
         Context $context,
         int $phpVersion
@@ -98,7 +102,9 @@ final class PossiblyInvalidArgumentForSpecifierValidator implements AfterEveryFu
                 $template,
                 $context,
                 $phpVersion,
-                self::$allowIntegerForStringPlaceholder
+                self::$allowIntegerForStringPlaceholder,
+                $statementsSource,
+                $codeLocation
             );
         } catch (InvalidArgumentException $exception) {
             return;

--- a/src/EventHandler/PossiblyInvalidArgumentForSpecifierValidator.php
+++ b/src/EventHandler/PossiblyInvalidArgumentForSpecifierValidator.php
@@ -103,8 +103,7 @@ final class PossiblyInvalidArgumentForSpecifierValidator implements AfterEveryFu
                 $context,
                 $phpVersion,
                 self::$allowIntegerForStringPlaceholder,
-                $statementsSource,
-                $codeLocation
+                $statementsSource
             );
         } catch (InvalidArgumentException $exception) {
             return;

--- a/src/EventHandler/SprintfFunctionReturnProvider.php
+++ b/src/EventHandler/SprintfFunctionReturnProvider.php
@@ -39,13 +39,17 @@ final class SprintfFunctionReturnProvider implements FunctionReturnTypeProviderI
 
         $templateArgument = $functionCallArguments[self::TEMPLATE_ARGUMENT_POSITION];
         $context          = $event->getContext();
+        $statementSource  = $event->getStatementsSource();
+        $codeLocation     = $event->getCodeLocation();
         try {
             $parser = TemplatedStringParser::fromArgument(
                 $functionName,
                 $templateArgument,
                 $context,
-                PhpVersion::fromStatementSource($event->getStatementsSource()),
-                false
+                PhpVersion::fromStatementSource($statementSource),
+                false,
+                $statementSource,
+                $codeLocation
             );
         } catch (InvalidArgumentException $exception) {
             return null;

--- a/src/EventHandler/SprintfFunctionReturnProvider.php
+++ b/src/EventHandler/SprintfFunctionReturnProvider.php
@@ -40,7 +40,6 @@ final class SprintfFunctionReturnProvider implements FunctionReturnTypeProviderI
         $templateArgument = $functionCallArguments[self::TEMPLATE_ARGUMENT_POSITION];
         $context          = $event->getContext();
         $statementSource  = $event->getStatementsSource();
-        $codeLocation     = $event->getCodeLocation();
         try {
             $parser = TemplatedStringParser::fromArgument(
                 $functionName,
@@ -48,8 +47,7 @@ final class SprintfFunctionReturnProvider implements FunctionReturnTypeProviderI
                 $context,
                 PhpVersion::fromStatementSource($statementSource),
                 false,
-                $statementSource,
-                $codeLocation
+                $statementSource
             );
         } catch (InvalidArgumentException $exception) {
             return null;

--- a/src/EventHandler/StringfFunctionArgumentValidator.php
+++ b/src/EventHandler/StringfFunctionArgumentValidator.php
@@ -17,6 +17,7 @@ use Psalm\Issue\TooManyArguments;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\AfterEveryFunctionCallAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterEveryFunctionCallAnalysisEvent;
+use Psalm\StatementsSource;
 use Webmozart\Assert\Assert;
 
 use function assert;
@@ -110,8 +111,11 @@ final class StringfFunctionArgumentValidator implements AfterEveryFunctionCallAn
         Assert::isNonEmptyList($arguments);
         Assert::allIsInstanceOf($arguments, Arg::class);
 
+        $statementsSource = $event->getStatementsSource();
+
         (new self($functionCall, $functionId, $arguments))->validate(
-            new CodeLocation($event->getStatementsSource(), $functionCall),
+            $statementsSource,
+            new CodeLocation($statementsSource, $functionCall),
             $argumentIndex,
             $event->getContext(),
             PhpVersion::fromCodebase($event->getCodebase())
@@ -123,6 +127,7 @@ final class StringfFunctionArgumentValidator implements AfterEveryFunctionCallAn
      * @psalm-param positive-int $phpVersion
      */
     private function validate(
+        StatementsSource $statementsSource,
         CodeLocation $codeLocation,
         int $templateArgumentIndex,
         Context $context,
@@ -136,7 +141,9 @@ final class StringfFunctionArgumentValidator implements AfterEveryFunctionCallAn
                 $template,
                 $context,
                 $phpVersion,
-                false
+                false,
+                $statementsSource,
+                $codeLocation
             );
         } catch (InvalidArgumentException $exception) {
             return;

--- a/src/EventHandler/StringfFunctionArgumentValidator.php
+++ b/src/EventHandler/StringfFunctionArgumentValidator.php
@@ -142,8 +142,7 @@ final class StringfFunctionArgumentValidator implements AfterEveryFunctionCallAn
                 $context,
                 $phpVersion,
                 false,
-                $statementsSource,
-                $codeLocation
+                $statementsSource
             );
         } catch (InvalidArgumentException $exception) {
             return;

--- a/src/EventHandler/UnnecessaryFunctionCallValidator.php
+++ b/src/EventHandler/UnnecessaryFunctionCallValidator.php
@@ -14,6 +14,7 @@ use Psalm\Context;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\AfterEveryFunctionCallAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterEveryFunctionCallAnalysisEvent;
+use Psalm\StatementsSource;
 use Webmozart\Assert\Assert;
 
 use function in_array;
@@ -61,14 +62,16 @@ final class UnnecessaryFunctionCallValidator implements AfterEveryFunctionCallAn
         Assert::isNonEmptyList($arguments);
         Assert::allIsInstanceOf($arguments, Arg::class);
 
-        $context = $event->getContext();
+        $context          = $event->getContext();
+        $statementsSource = $event->getStatementsSource();
 
         /** @psalm-suppress InvalidScalarArgument */
         (new self(
             $functionId,
             $arguments
         ))->assert(
-            new CodeLocation($event->getStatementsSource(), $expression),
+            $statementsSource,
+            new CodeLocation($statementsSource, $expression),
             $context,
             PhpVersion::fromCodebase($event->getCodebase())
         );
@@ -78,6 +81,7 @@ final class UnnecessaryFunctionCallValidator implements AfterEveryFunctionCallAn
      * @psalm-param positive-int $phpVersion
      */
     private function assert(
+        StatementsSource $statementsSource,
         CodeLocation $codeLocation,
         Context $context,
         int $phpVersion
@@ -90,7 +94,9 @@ final class UnnecessaryFunctionCallValidator implements AfterEveryFunctionCallAn
                 $template,
                 $context,
                 $phpVersion,
-                false
+                false,
+                $statementsSource,
+                $codeLocation
             );
         } catch (InvalidArgumentException $exception) {
             return;

--- a/src/EventHandler/UnnecessaryFunctionCallValidator.php
+++ b/src/EventHandler/UnnecessaryFunctionCallValidator.php
@@ -95,8 +95,7 @@ final class UnnecessaryFunctionCallValidator implements AfterEveryFunctionCallAn
                 $context,
                 $phpVersion,
                 false,
-                $statementsSource,
-                $codeLocation
+                $statementsSource
             );
         } catch (InvalidArgumentException $exception) {
             return;

--- a/src/Parser/PhpParser/ReturnTypeParser.php
+++ b/src/Parser/PhpParser/ReturnTypeParser.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boesing\PsalmPluginStringf\Parser\PhpParser;
+
+use InvalidArgumentException;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use Psalm\CodeLocation;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\StatementsSource;
+use Psalm\Type\Union;
+use Webmozart\Assert\Assert;
+
+use function sprintf;
+use function strtolower;
+
+final class ReturnTypeParser
+{
+    private StatementsSource $statementsSource;
+
+    private CodeLocation $codeLocation;
+
+    private FuncCall $value;
+
+    private function __construct(StatementsSource $statementsSource, CodeLocation $codeLocation, FuncCall $value)
+    {
+        $this->statementsSource = $statementsSource;
+        $this->codeLocation     = $codeLocation;
+        $this->value            = $value;
+    }
+
+    public static function create(
+        StatementsSource $statementsSource,
+        CodeLocation $codeLocation,
+        FuncCall $value
+    ): self {
+        return new self($statementsSource, $codeLocation, $value);
+    }
+
+    public function toType(): Union
+    {
+        $name = $this->value->name;
+        Assert::isInstanceOf($name, Name::class, 'Could not detect function name.');
+
+        $source = $this->statementsSource;
+        if (! $source instanceof StatementsAnalyzer) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid statements source given. Can only handle %s at this time.',
+                StatementsAnalyzer::class
+            ));
+        }
+
+        $function_id = strtolower($name->toString());
+
+        /** @psalm-suppress InternalMethod I don't see any other way of detecting the return type of a function (yet) */
+        $analyzer = $source->getFunctionAnalyzer($function_id);
+        if ($analyzer === null) {
+            throw new InvalidArgumentException(sprintf(
+                'Could not detect function analyzer for `function_id`: %s',
+                $function_id
+            ));
+        }
+
+        /** @psalm-suppress InternalMethod I don't see any other way of detecting the return type of a function (yet) */
+        $storage              = $analyzer->getFunctionLikeStorage($source);
+        $declared_return_type = $storage->return_type;
+        if ($declared_return_type === null) {
+            throw new InvalidArgumentException(sprintf('Could not detect return type for `function_id`: %s', $function_id));
+        }
+
+        return $declared_return_type;
+    }
+}

--- a/src/Parser/PhpParser/ReturnTypeParser.php
+++ b/src/Parser/PhpParser/ReturnTypeParser.php
@@ -5,43 +5,70 @@ declare(strict_types=1);
 namespace Boesing\PsalmPluginStringf\Parser\PhpParser;
 
 use InvalidArgumentException;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
-use Psalm\CodeLocation;
+use Psalm\Context;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\StatementsSource;
+use Psalm\Storage\MethodStorage;
+use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 use Webmozart\Assert\Assert;
 
+use function get_class;
+use function is_string;
 use function sprintf;
-use function strtolower;
 
 final class ReturnTypeParser
 {
     private StatementsSource $statementsSource;
 
-    private CodeLocation $codeLocation;
+    private Context $context;
 
-    private FuncCall $value;
+    /** @var FuncCall|StaticCall|MethodCall */
+    private Expr $value;
 
-    private function __construct(StatementsSource $statementsSource, CodeLocation $codeLocation, FuncCall $value)
+    /**
+     * @param FuncCall|StaticCall|MethodCall $value
+     */
+    private function __construct(StatementsSource $statementsSource, Context $context, Expr $value)
     {
         $this->statementsSource = $statementsSource;
-        $this->codeLocation     = $codeLocation;
+        $this->context          = $context;
         $this->value            = $value;
     }
 
+    /**
+     * @param FuncCall|StaticCall|MethodCall $value
+     */
     public static function create(
         StatementsSource $statementsSource,
-        CodeLocation $codeLocation,
-        FuncCall $value
+        Context $context,
+        Expr $value
     ): self {
-        return new self($statementsSource, $codeLocation, $value);
+        return new self($statementsSource, $context, $value);
     }
 
     public function toType(): Union
     {
-        $name = $this->value->name;
+        if ($this->value instanceof FuncCall) {
+            return $this->detectTypeFromFunctionCall($this->value);
+        }
+
+        if ($this->value instanceof StaticCall) {
+            return $this->detectTypeFromStaticMethodCall($this->value);
+        }
+
+        return $this->detectTypeFromMethodCall($this->value);
+    }
+
+    private function detectTypeFromFunctionCall(FuncCall $value): Union
+    {
+        $name = $value->name;
         Assert::isInstanceOf($name, Name::class, 'Could not detect function name.');
 
         $source = $this->statementsSource;
@@ -52,7 +79,7 @@ final class ReturnTypeParser
             ));
         }
 
-        $function_id = strtolower($name->toString());
+        $function_id = $name->toLowerString();
 
         /** @psalm-suppress InternalMethod I don't see any other way of detecting the return type of a function (yet) */
         $analyzer = $source->getFunctionAnalyzer($function_id);
@@ -71,5 +98,120 @@ final class ReturnTypeParser
         }
 
         return $declared_return_type;
+    }
+
+    private function detectTypeFromStaticMethodCall(StaticCall $value): Union
+    {
+        $class = $value->class;
+        if (! $class instanceof Name) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected `class` to be instance of `%s`: `%s` given.',
+                Name::class,
+                get_class($class)
+            ));
+        }
+
+        $method = $value->name;
+        if (! $method instanceof Identifier) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected `name` to be instance of `%s`: `%s` given.',
+                Identifier::class,
+                get_class($method)
+            ));
+        }
+
+        /** @var class-string $className */
+        $className = $class->toString();
+
+        return $this->detectTypeFromMethodCallOfClass($method, $className);
+    }
+
+    private function detectTypeFromMethodCall(MethodCall $value): Union
+    {
+        $class  = $this->detectClass($value->var);
+        $method = $value->name;
+
+        if (! $method instanceof Identifier) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected `name` to be instance of `%s`: `%s` given.',
+                Identifier::class,
+                get_class($method)
+            ));
+        }
+
+        return $this->detectTypeFromMethodCallOfClass($method, $class);
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function detectTypeFromMethodCallOfClass(Identifier $method, string $class): Union
+    {
+        /** @psalm-suppress InternalMethod We need the class like storage to detect the return type of the method call of a specific class. */
+        $classLikeStorage = $this->statementsSource->getCodebase()->classlike_storage_provider->get($class);
+        /** @var lowercase-string $lowercasedMethodName */
+        $lowercasedMethodName = $method->toLowerString();
+        $methodStorage        = $classLikeStorage->methods[$lowercasedMethodName] ?? null;
+        if (! $methodStorage instanceof MethodStorage) {
+            throw new InvalidArgumentException(
+                'Provided static call does contain a method call to a method which can not be found within the methods parsed from the class.'
+            );
+        }
+
+        $returnType = $methodStorage->return_type;
+        if ($returnType === null) {
+            throw new InvalidArgumentException(sprintf('Could not detect return type for method call: %s::%s', $class, $method->toString()));
+        }
+
+        return $returnType;
+    }
+
+    /** @return class-string */
+    private function detectClass(Expr $var): string
+    {
+        if ($var instanceof Expr\New_) {
+            $class = $var->class;
+            if (! $class instanceof Name) {
+                throw new InvalidArgumentException(sprintf(
+                    'Expected `class` to be instance of `%s`: `%s` given.',
+                    Name::class,
+                    get_class($class)
+                ));
+            }
+
+            /** @var class-string $className */
+            $className = $class->toString();
+
+            return $className;
+        }
+
+        if ($var instanceof Expr\Variable) {
+            $variableName = $var->name;
+            if (! is_string($variableName)) {
+                throw new InvalidArgumentException('Can\'t handle non-string variable name');
+            }
+
+            $variableNameWithLeadingDollar = sprintf('$%s', $variableName);
+            if (! isset($this->context->vars_possibly_in_scope[$variableNameWithLeadingDollar])) {
+                throw new InvalidArgumentException('Used variable is unknown in context');
+            }
+
+            $variable = $this->context->vars_in_scope[$variableNameWithLeadingDollar];
+            if (! $variable->isSingle()) {
+                throw new InvalidArgumentException('Unable to detect class name from non-single typed variable.');
+            }
+
+            $type = $variable->getSingleAtomic();
+            if (! $type instanceof TNamedObject) {
+                throw new InvalidArgumentException('Unable to detect class name from non-named object.');
+            }
+
+            /** @var class-string $className */
+            $className = $type->value;
+
+            return $className;
+        }
+
+        throw new InvalidArgumentException(sprintf('Unable to parse class name from expression of type: %s', get_class($var)));
     }
 }

--- a/src/Parser/TemplatedStringParser/Placeholder.php
+++ b/src/Parser/TemplatedStringParser/Placeholder.php
@@ -10,7 +10,6 @@ use Boesing\PsalmPluginStringf\Parser\Psalm\TypeParser;
 use InvalidArgumentException;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\StatementsSource;
 use Psalm\Type\Atomic\TNonEmptyString;
@@ -35,8 +34,6 @@ final class Placeholder
 
     private StatementsSource $statementsSource;
 
-    private CodeLocation $codeLocation;
-
     /**
      * @psalm-param non-empty-string $value
      * @psalm-param positive-int $position
@@ -45,8 +42,7 @@ final class Placeholder
         string $value,
         int $position,
         bool $allowIntegerForStringPlaceholder,
-        StatementsSource $statementsSource,
-        CodeLocation $codeLocation
+        StatementsSource $statementsSource
     ) {
         $this->value                            = $value;
         $this->position                         = $position;
@@ -54,16 +50,15 @@ final class Placeholder
         $this->type                             = null;
         $this->allowIntegerForStringPlaceholder = $allowIntegerForStringPlaceholder;
         $this->statementsSource                 = $statementsSource;
-        $this->codeLocation                     = $codeLocation;
     }
 
     /**
      * @psalm-param non-empty-string $value
      * @psalm-param positive-int $position
      */
-    public static function create(string $value, int $position, bool $allowIntegerForStringPlaceholder, StatementsSource $statementsSource, CodeLocation $codeLocation): self
+    public static function create(string $value, int $position, bool $allowIntegerForStringPlaceholder, StatementsSource $statementsSource): self
     {
-        return new self($value, $position, $allowIntegerForStringPlaceholder, $statementsSource, $codeLocation);
+        return new self($value, $position, $allowIntegerForStringPlaceholder, $statementsSource);
     }
 
     /**
@@ -176,8 +171,8 @@ final class Placeholder
 
     private function getArgumentValueType(Expr $value, Context $context): Union
     {
-        if ($value instanceof Expr\FuncCall) {
-            return ReturnTypeParser::create($this->statementsSource, $this->codeLocation, $value)->toType();
+        if ($value instanceof Expr\FuncCall || $value instanceof Expr\StaticCall || $value instanceof Expr\MethodCall) {
+            return ReturnTypeParser::create($this->statementsSource, $context, $value)->toType();
         }
 
         return ArgumentValueParser::create($value, $context)->toType();

--- a/src/Parser/TemplatedStringParser/Placeholder.php
+++ b/src/Parser/TemplatedStringParser/Placeholder.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Boesing\PsalmPluginStringf\Parser\TemplatedStringParser;
 
 use Boesing\PsalmPluginStringf\Parser\PhpParser\ArgumentValueParser;
+use Boesing\PsalmPluginStringf\Parser\PhpParser\ReturnTypeParser;
 use Boesing\PsalmPluginStringf\Parser\Psalm\TypeParser;
 use InvalidArgumentException;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use Psalm\CodeLocation;
 use Psalm\Context;
+use Psalm\StatementsSource;
 use Psalm\Type\Atomic\TNonEmptyString;
 use Psalm\Type\Union;
 
@@ -29,39 +33,37 @@ final class Placeholder
 
     private bool $allowIntegerForStringPlaceholder;
 
+    private StatementsSource $statementsSource;
+
+    private CodeLocation $codeLocation;
+
     /**
      * @psalm-param non-empty-string $value
      * @psalm-param positive-int $position
      */
-    private function __construct(string $value, int $position, bool $allowIntegerForStringPlaceholder)
-    {
+    private function __construct(
+        string $value,
+        int $position,
+        bool $allowIntegerForStringPlaceholder,
+        StatementsSource $statementsSource,
+        CodeLocation $codeLocation
+    ) {
         $this->value                            = $value;
         $this->position                         = $position;
         $this->argumentValueType                = null;
         $this->type                             = null;
         $this->allowIntegerForStringPlaceholder = $allowIntegerForStringPlaceholder;
+        $this->statementsSource                 = $statementsSource;
+        $this->codeLocation                     = $codeLocation;
     }
 
     /**
      * @psalm-param non-empty-string $value
      * @psalm-param positive-int $position
      */
-    public static function create(string $value, int $position, bool $allowIntegerForStringPlaceholder): self
+    public static function create(string $value, int $position, bool $allowIntegerForStringPlaceholder, StatementsSource $statementsSource, CodeLocation $codeLocation): self
     {
-        return new self($value, $position, $allowIntegerForStringPlaceholder);
-    }
-
-    /**
-     * @psalm-param non-empty-list<Arg> $functionCallArguments
-     */
-    public function getArgumentValue(array $functionCallArguments, Context $context): ?string
-    {
-        $type = $this->getArgumentType($functionCallArguments, $context);
-        if ($type === null) {
-            return null;
-        }
-
-        return TypeParser::create($type)->stringify();
+        return new self($value, $position, $allowIntegerForStringPlaceholder, $statementsSource, $codeLocation);
     }
 
     /**
@@ -98,7 +100,7 @@ final class Placeholder
         }
 
         try {
-            $this->argumentValueType = ArgumentValueParser::create($argument->value, $context)->toType();
+            $this->argumentValueType = $this->getArgumentValueType($argument->value, $context);
         } catch (InvalidArgumentException $exception) {
             return null;
         }
@@ -170,5 +172,14 @@ final class Placeholder
         }
 
         return $this->type = new Union($types);
+    }
+
+    private function getArgumentValueType(Expr $value, Context $context): Union
+    {
+        if ($value instanceof Expr\FuncCall) {
+            return ReturnTypeParser::create($this->statementsSource, $this->codeLocation, $value)->toType();
+        }
+
+        return ArgumentValueParser::create($value, $context)->toType();
     }
 }

--- a/src/Parser/TemplatedStringParser/TemplatedStringParser.php
+++ b/src/Parser/TemplatedStringParser/TemplatedStringParser.php
@@ -6,7 +6,6 @@ namespace Boesing\PsalmPluginStringf\Parser\TemplatedStringParser;
 
 use Boesing\PsalmPluginStringf\Parser\PhpParser\ArgumentValueParser;
 use PhpParser\Node\Arg;
-use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\StatementsSource;
 use Webmozart\Assert\Assert;
@@ -46,8 +45,6 @@ final class TemplatedStringParser
 
     private StatementsSource $statementsSource;
 
-    private CodeLocation $codeLocation;
-
     /**
      * @psalm-param positive-int $phpVersion
      */
@@ -56,14 +53,12 @@ final class TemplatedStringParser
         string $template,
         int $phpVersion,
         bool $allowIntegerForStringPlaceholder,
-        StatementsSource $statementsSource,
-        CodeLocation $codeLocation
+        StatementsSource $statementsSource
     ) {
         $this->template                   = $template;
         $this->templateWithoutPlaceholder = $template;
         $this->placeholders               = [];
         $this->statementsSource           = $statementsSource;
-        $this->codeLocation               = $codeLocation;
         $this->parse($functionName, $template, $phpVersion, $allowIntegerForStringPlaceholder);
     }
 
@@ -147,8 +142,7 @@ final class TemplatedStringParser
                 $placeholderValue,
                 $placeholderPosition,
                 $allowIntegerForStringPlaceholder,
-                $this->statementsSource,
-                $this->codeLocation
+                $this->statementsSource
             );
 
             if ($initialPlaceholderInstance !== null) {
@@ -170,16 +164,14 @@ final class TemplatedStringParser
         Context $context,
         int $phpVersion,
         bool $allowIntegerForStringPlaceholder,
-        StatementsSource $statementsSource,
-        CodeLocation $codeLocation
+        StatementsSource $statementsSource
     ): self {
         return new self(
             $functionName,
             ArgumentValueParser::create($templateArgument->value, $context)->toString(),
             $phpVersion,
             $allowIntegerForStringPlaceholder,
-            $statementsSource,
-            $codeLocation
+            $statementsSource
         );
     }
 

--- a/src/Parser/TemplatedStringParser/TemplatedStringParser.php
+++ b/src/Parser/TemplatedStringParser/TemplatedStringParser.php
@@ -6,7 +6,9 @@ namespace Boesing\PsalmPluginStringf\Parser\TemplatedStringParser;
 
 use Boesing\PsalmPluginStringf\Parser\PhpParser\ArgumentValueParser;
 use PhpParser\Node\Arg;
+use Psalm\CodeLocation;
 use Psalm\Context;
+use Psalm\StatementsSource;
 use Webmozart\Assert\Assert;
 
 use function array_filter;
@@ -42,7 +44,9 @@ final class TemplatedStringParser
 
     private string $template;
 
-    private bool $allowIntegerForStringPlaceholder;
+    private StatementsSource $statementsSource;
+
+    private CodeLocation $codeLocation;
 
     /**
      * @psalm-param positive-int $phpVersion
@@ -51,13 +55,16 @@ final class TemplatedStringParser
         string $functionName,
         string $template,
         int $phpVersion,
-        bool $allowIntegerForStringPlaceholder
+        bool $allowIntegerForStringPlaceholder,
+        StatementsSource $statementsSource,
+        CodeLocation $codeLocation
     ) {
         $this->template                   = $template;
         $this->templateWithoutPlaceholder = $template;
         $this->placeholders               = [];
+        $this->statementsSource           = $statementsSource;
+        $this->codeLocation               = $codeLocation;
         $this->parse($functionName, $template, $phpVersion, $allowIntegerForStringPlaceholder);
-        $this->allowIntegerForStringPlaceholder = $allowIntegerForStringPlaceholder;
     }
 
     private function parse(
@@ -139,7 +146,9 @@ final class TemplatedStringParser
             $placeholderInstance        = Placeholder::create(
                 $placeholderValue,
                 $placeholderPosition,
-                $allowIntegerForStringPlaceholder
+                $allowIntegerForStringPlaceholder,
+                $this->statementsSource,
+                $this->codeLocation
             );
 
             if ($initialPlaceholderInstance !== null) {
@@ -160,13 +169,17 @@ final class TemplatedStringParser
         Arg $templateArgument,
         Context $context,
         int $phpVersion,
-        bool $allowIntegerForStringPlaceholder
+        bool $allowIntegerForStringPlaceholder,
+        StatementsSource $statementsSource,
+        CodeLocation $codeLocation
     ): self {
         return new self(
             $functionName,
             ArgumentValueParser::create($templateArgument->value, $context)->toString(),
             $phpVersion,
-            $allowIntegerForStringPlaceholder
+            $allowIntegerForStringPlaceholder,
+            $statementsSource,
+            $codeLocation
         );
     }
 

--- a/tests/acceptance/SprintfNonEmptyString.feature
+++ b/tests/acceptance/SprintfNonEmptyString.feature
@@ -24,7 +24,7 @@ Feature: non empty template passed to sprintf results in non-empty-string
     {}
     """
 
-  Scenario: template is empty but value which is passed to the string is boolean (true) (<5.0)
+  Scenario: template is empty but value which is passed to the string is boolean (true)
     Given I have the following code
     """
       /**

--- a/tests/acceptance/SprintfNonEmptyString.feature
+++ b/tests/acceptance/SprintfNonEmptyString.feature
@@ -244,3 +244,19 @@ Feature: non empty template passed to sprintf results in non-empty-string
     """
     When I run psalm
     Then I see no errors
+
+  Scenario: template is non-empty because non-empty-string is being returned from called function
+    Given I have the following code
+    """
+      /** @return non-empty-string */
+      function createNonEmptyString(): string
+      {
+          return 'foo';
+      }
+
+      nonEmptyString(sprintf('%s', createNonEmptyString()));
+    """
+    When I run psalm
+    Then I see no errors
+
+

--- a/tests/acceptance/SprintfNonEmptyString.feature
+++ b/tests/acceptance/SprintfNonEmptyString.feature
@@ -259,4 +259,54 @@ Feature: non empty template passed to sprintf results in non-empty-string
     When I run psalm
     Then I see no errors
 
+  Scenario: template is non-empty because non-empty-string is being returned from statically called method
+    Given I have the following code
+    """
+      final class Foo
+      {
+          /** @return non-empty-string */
+          public static function createNonEmptyString(): string
+          {
+              return 'foo';
+          }
+      }
 
+      nonEmptyString(sprintf('%s', Foo::createNonEmptyString()));
+    """
+    When I run psalm
+    Then I see no errors
+
+  Scenario: template is non-empty because non-empty-string is being returned from called method
+    Given I have the following code
+    """
+      final class Foo
+      {
+          /** @return non-empty-string */
+          public function createNonEmptyString(): string
+          {
+              return 'foo';
+          }
+      }
+
+      $foo = new Foo();
+      nonEmptyString(sprintf('%s', (new Foo())->createNonEmptyString()));
+      nonEmptyString(sprintf('%s', $foo->createNonEmptyString()));
+    """
+    When I run psalm
+    Then I see no errors
+
+  Scenario: template is non-empty because non-empty-string is being returned from called method of anonymous class
+    Given I have the following code
+    """
+      $foo = new class {
+        /** @return non-empty-string */
+        public function createNonEmptyString(): string
+        {
+          return 'foo';
+        }
+      };
+
+      nonEmptyString(sprintf('%s', $foo->createNonEmptyString()));
+    """
+    When I run psalm
+    Then I see no errors


### PR DESCRIPTION
This enables the plugin to also detect return types of method and function calls which are being passed to the stringf functions.

fixes #86 